### PR TITLE
client & sdk mutex

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@stratumn/canonicaljson": "^1.0.3",
     "@stratumn/js-chainscript": "^1.0.7",
     "@stratumn/js-crypto": "^1.4.0",
+    "async-mutex": "^0.1.3",
     "await-to-js": "^2.1.1",
     "bcryptjs": "^2.4.3",
     "form-data": "^2.4.0",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -199,7 +199,7 @@ describe('Client', () => {
       /**
        * Here we test how the client behaves under concurrent execution.
        * Since the client maintain a state for the token, there is a risk
-       * of concurrent login / writting of the token. This can happen at
+       * of concurrent login / writing of the token. This can happen at
        * two moments: the first time we login (fresh after the sdk is instanciated)
        * and when the token expires and receives 401s.
        *

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -7,6 +7,7 @@ import {
 } from '../types';
 import { FileWrapper } from '../fileWrapper';
 import { FileRecord } from '../fileRecord';
+import { ConfigQuery, CreateLinkMutation } from '../graphql';
 
 export namespace fixtures {
   export namespace signingKey {
@@ -86,5 +87,48 @@ export namespace fixtures {
   export namespace FileRecords {
     export const obj = fileObj;
     export const fileRecord = FileRecord.fromObject(fileObj);
+  }
+
+  export namespace Sdk {
+    export const workflowId = traceLink.workflowId;
+    export const configQueryRsp: ConfigQuery.Response = {
+      account: {
+        userId: '117',
+        accountId: '225',
+        memberOf: {
+          nodes: [{ accountId: '123' }]
+        },
+        account: {
+          signingKey: {
+            privateKey: {
+              decrypted: signingKey.pemPrivateKey,
+              passwordProtected: false
+            }
+          }
+        }
+      },
+      workflow: {
+        groups: {
+          nodes: [{ accountId: '123', groupId: '887' }]
+        }
+      }
+    };
+    export const createLinkMutationImpl = (
+      variables: CreateLinkMutation.Variables
+    ) => {
+      const createLinkMutationRsp: CreateLinkMutation.Response = {
+        createLink: {
+          trace: {
+            head: {
+              data: variables.data,
+              raw: variables.link
+            },
+            state: {},
+            updatedAt: new Date().toString()
+          }
+        }
+      };
+      return createLinkMutationRsp;
+    };
   }
 }

--- a/src/sdk.spec.ts
+++ b/src/sdk.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { mocked } from 'ts-jest/utils';
+import { Sdk } from './sdk';
+import { Client } from './client';
+import { fixtures } from './fixtures';
+
+jest.mock('./client');
+const mockClientCtor = mocked(Client);
+
+describe('Sdk', () => {
+  let sdk: Sdk;
+  beforeEach(() => {
+    mockClientCtor.mockClear();
+    sdk = new Sdk({
+      secret: {
+        privateKey: fixtures.signingKey.pemPrivateKey
+      },
+      workflowId: fixtures.Sdk.workflowId
+    });
+  });
+
+  it('instanciates a client', () => {
+    expect(mockClientCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrency', async () => {
+    const mockClient = mocked(mockClientCtor.mock.instances[0]);
+    const { configQueryRsp, createLinkMutationImpl } = fixtures.Sdk;
+    const graphqlImpl = (query: string, variables: any) => {
+      const trimmedQuery = query.trim();
+      if (trimmedQuery.startsWith('query configQuery')) {
+        return configQueryRsp;
+      }
+      if (trimmedQuery.startsWith('mutation createLinkMutation')) {
+        return createLinkMutationImpl(variables);
+      }
+      throw new Error();
+    };
+    mockClient.graphql.mockImplementation(graphqlImpl as any);
+    await Promise.all([
+      sdk.newTrace({ formId: '42', data: {} }),
+      sdk.newTrace({ formId: '43', data: {} }),
+      sdk.newTrace({ formId: '44', data: {} }),
+      sdk.newTrace({ formId: '45', data: {} })
+    ]);
+    expect(mockClient.graphql).toHaveBeenCalledTimes(5);
+    expect(
+      mockClient.graphql.mock.calls.map(([query]) => query.trim().split('(')[0])
+    ).toEqual([
+      'query configQuery',
+      'mutation createLinkMutation',
+      'mutation createLinkMutation',
+      'mutation createLinkMutation',
+      'mutation createLinkMutation'
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,10 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async-mutex@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.1.3.tgz#0aad2112369795ab3f17e33744556d2ecf547566"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"


### PR DESCRIPTION
In this PR we introduce a mutex in `Sdk` and `Client` classes to cope with concurrency and the state maintained by both classes. I've discussed this strategy with @simonvadee and it seems the most efficient to avoid doing multiple config queries or multiple logins.

I've added an extensive test in the `client.spec.ts` file that explains clearly what we are testing under which circumstances. I also added a new `sdk.spec.ts` to test the mutex behavior in the `Sdk`. I will add more tests in this file but this is not the point of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/9)
<!-- Reviewable:end -->
