### PR TITLE
Update: Add links to trace fragment for client side state computation

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -38,6 +38,14 @@ export namespace Fragments {
           raw
           data
         }
+        # TODO: temporary, remove once state computation
+        # is handled server side
+        links {
+          nodes {
+            raw
+            data
+          }
+        }
       }
     `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * from './fileWrapper';
 export * from './fileRecord';
 export { SdkOptions } from './types/sdk';
 export * from './types/trace';
+export * from './traceLink';
+export * from './traceLinkBuilder';


### PR DESCRIPTION
- temporarily query the `links` of a trace to ease state computation client side
- export TraceLink and TraceLinkBuilder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/14)
<!-- Reviewable:end -->
