### PR TITLE
Update: Load forms action names

### DIFF
--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -108,6 +108,9 @@ export namespace fixtures {
         }
       },
       workflow: {
+        forms: {
+          nodes: [{ formId: '123', stageName: 'the action' }]
+        },
         groups: {
           nodes: [{ accountId: '123', groupId: '887' }]
         }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -149,6 +149,12 @@ export namespace ConfigQuery {
         }
       }
       workflow: workflowByRowId(rowId: $workflowId) {
+        forms {
+          nodes {
+            formId: rowId
+            stageName
+          }
+        }
         groups {
           nodes {
             groupId: rowId
@@ -182,6 +188,12 @@ export namespace ConfigQuery {
       };
     };
     workflow: {
+      forms: {
+        nodes: {
+          formId: string;
+          stageName: string;
+        }[];
+      };
       groups: {
         nodes: {
           groupId: string;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -166,6 +166,12 @@ export class Sdk<TState = any> {
         throw new Error('Cannot get signing private key');
       }
 
+      // extract action names
+      const actionNames: { [formId: string]: string } = {};
+      workflow.forms.nodes.forEach(f => {
+        actionNames[f.formId] = f.stageName;
+      });
+
       // store the new config
       this.config = {
         workflowId,
@@ -173,6 +179,7 @@ export class Sdk<TState = any> {
         accountId,
         groupId,
         ownerId,
+        actionNames,
         signingPrivateKey
       };
 
@@ -462,7 +469,13 @@ export class Sdk<TState = any> {
     const { data, formId } = input;
 
     // extract info from config
-    const { workflowId, userId, ownerId, groupId } = await this.getConfig();
+    const {
+      workflowId,
+      userId,
+      ownerId,
+      groupId,
+      actionNames
+    } = await this.getConfig();
 
     // upload files and transform data
     const dataAfterFileUpload = await this.uploadFilesInLinkData(data);
@@ -473,7 +486,7 @@ export class Sdk<TState = any> {
       workflowId
     })
       // this is an attestation
-      .forAttestation(formId, dataAfterFileUpload)
+      .forAttestation(formId, actionNames[formId], dataAfterFileUpload)
       // add owner info
       .withOwner(ownerId)
       // add group info
@@ -524,7 +537,13 @@ export class Sdk<TState = any> {
     const { data, formId } = input;
 
     // extract info from config
-    const { workflowId, userId, ownerId, groupId } = await this.getConfig();
+    const {
+      workflowId,
+      userId,
+      ownerId,
+      groupId,
+      actionNames
+    } = await this.getConfig();
 
     // upload files and transform data
     const dataAfterFileUpload = await this.uploadFilesInLinkData(data);
@@ -537,7 +556,7 @@ export class Sdk<TState = any> {
       parentLink
     })
       // this is an attestation
-      .forAttestation(formId, dataAfterFileUpload)
+      .forAttestation(formId, actionNames[formId], dataAfterFileUpload)
       // add owner info
       .withOwner(ownerId)
       // add group info

--- a/src/traceLinkBuilder.spec.ts
+++ b/src/traceLinkBuilder.spec.ts
@@ -29,7 +29,7 @@ describe('TraceLinkBuilder', () => {
   beforeEach(() => {
     mockUuid.mockReturnValue(traceId as any);
     builder = new TraceLinkBuilder({ workflowId })
-      .forAttestation(formId, data)
+      .forAttestation(formId, 'action', data)
       .withOwner(ownerId)
       .withGroup(groupId)
       .withCreatedBy(createdById);
@@ -62,7 +62,7 @@ describe('TraceLinkBuilder', () => {
 
   it('forAttestation', () => {
     const link = builder.build();
-    const expectedAction: TraceActionType = '_ATTESTATION_';
+    const expectedAction: string = 'action';
     const expectedType: TraceLinkType = 'OWNED';
     expect(link.formData()).toEqual(data);
     expect(link.data()).toEqual(hashedData);

--- a/src/traceLinkBuilder.ts
+++ b/src/traceLinkBuilder.ts
@@ -104,13 +104,13 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
    * User must still set owner, group and createdBy separately.
    *
    * @param formId the form id used for the attestation
+   * @param action the name of the action associated with the form
    * @param data the data of the attestation
    */
-  public forAttestation(formId: string, data: TLinkData) {
-    const action: TraceActionType = '_ATTESTATION_';
+  public forAttestation(formId: string, action: string, data: TLinkData) {
     const type: TraceLinkType = 'OWNED';
     this.withHashedData(data)
-      .withAction(action)
+      .withAction(action || 'Attestation')
       .withProcessState(type);
     this.metadata.formId = formId;
     return this;

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -44,4 +44,9 @@ export interface SdkConfig {
    * The private key used for signing links
    */
   signingPrivateKey: sig.SigningPrivateKey;
+
+  /**
+   * The actions names associated to each form
+   */
+  actionNames: { [formId: string]: string };
 }


### PR DESCRIPTION
The SDK currently set link.meta.action to `_ATTESTATION_` whereas it should be the form stage name.
We load the workflow forms upon SDK init to get those names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/19)
<!-- Reviewable:end -->
