### PR TITLE
Fix: Support null case in extractObjects

### DIFF
--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -136,6 +136,11 @@ describe('extractObjects / assignObjects', () => {
     expected: new Map([])
   };
 
+  const nullObject = {
+    value: null,
+    expected: new Map([])
+  };
+
   /**
    * Test that the FileWrapper objects are extracted correctly.
    */
@@ -143,7 +148,8 @@ describe('extractObjects / assignObjects', () => {
     ['nested object', nestedObject],
     ['array', array],
     ['object with no file', noFile],
-    ['undefined', undefinedObject]
+    ['undefined', undefinedObject],
+    ['null', nullObject]
   ])('extract file wrappers from %s', (_name, testObject) => {
     const { idToObjectMap, pathToIdMap } = extractFileWrappers(
       testObject.value

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,7 +105,7 @@ const extractObjectsImpl = <T, V extends Identifiable>(
         reviver
       );
     });
-  } else if (typeof data === 'object') {
+  } else if (data && typeof data === 'object') {
     // if it is an object, iterate through each entry
     // and extract objects recursively
     for (const [key, value] of Object.entries(data)) {


### PR DESCRIPTION
This allows `null` fields to be passed through the SDK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/23)
<!-- Reviewable:end -->
