### PR TITLE
log graphql request and responses in debugging mode

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,6 +76,11 @@ export class Client {
   private mutex: Mutex;
 
   /**
+   * enable request and response logging
+   */
+  private enableDebugging?: boolean;
+
+  /**
    * Constructs a new instance of the Client
    * @param opts the client options
    */
@@ -83,6 +88,7 @@ export class Client {
     this.endpoints = makeEndpoints(opts.endpoints);
     this.secret = opts.secret;
     this.mutex = new Mutex();
+    this.enableDebugging = opts.enableDebugging;
   }
 
   /*********************************************************
@@ -396,6 +402,14 @@ export class Client {
     // compile the trace graphql endpoint url to use
     const gqlUrl = new URL('graphql', this.endpoints.trace).toString();
 
+    if (this.enableDebugging) {
+      console.log(
+        '======================= GraphQL Request ======================='
+      );
+      console.log(query);
+      console.log(variables);
+    }
+
     // delegate the graphql request execution
     const [err, rsp] = await to<T, ClientError>(
       graphqlRequest<T>(
@@ -405,6 +419,14 @@ export class Client {
         variables
       )
     );
+
+    if (this.enableDebugging) {
+      console.log(
+        '======================= GraphQL Response ======================='
+      );
+      console.log(rsp);
+      if (err) console.log(err);
+    }
 
     const { retry } = opts || defaultGraphQLOptions;
 

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -92,6 +92,12 @@ export interface ClientOptions {
    * Can be a signing key or a username + password.
    */
   secret: Secret;
+
+  /**
+   * This option is used to add request and response logging
+   * for debugging purposes
+   */
+  enableDebugging?: boolean;
 }
 
 /**


### PR DESCRIPTION
Since this code is running at our client, and since we don't log data in our app logs (requests and responses, but maybe we should do this for staging), this is useful for debugging with the clients

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/24)
<!-- Reviewable:end -->
