### PR TITLE
Fix: update main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Stratumn Team",
   "private": false,
   "license": "Apache-2.0",
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "files": [
     "/lib"
   ],


### PR DESCRIPTION
In my last PR, I imported package.json from the client to get the package version in order to add it to the user agent.
I think the builder saw that and to add package.json to the build folder went one level up.

We used to have lib/index.ts
now we have lib/src/index.ts and lib/package.json

So this fixes that

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/27)
<!-- Reviewable:end -->
