### PR TITLE
Update: Add config ID to links (ALP-150)

### DIFF
--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -39,6 +39,7 @@ export namespace fixtures {
     };
     export const type: TraceLinkType = 'OWNED';
     export const ownerId = '563';
+    export const configId = '666';
     export const groupId = '877';
     export const actionKey = 'action zou';
     export const lastFormId = '325';
@@ -48,6 +49,7 @@ export namespace fixtures {
     export const createdById = '195587';
     export const metadata: TraceLinkMetaData = {
       ownerId,
+      configId,
       groupId,
       formId: actionKey,
       lastFormId,
@@ -108,6 +110,7 @@ export namespace fixtures {
         }
       },
       workflow: {
+        config: { id: '666' },
         groups: {
           nodes: [{ accountId: '123', groupId: '887' }]
         }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -149,6 +149,9 @@ export namespace ConfigQuery {
         }
       }
       workflow: workflowByRowId(rowId: $workflowId) {
+        config {
+          id: rowId
+        }
         groups {
           nodes {
             groupId: rowId
@@ -182,6 +185,7 @@ export namespace ConfigQuery {
       };
     };
     workflow: {
+      config: { id: string };
       groups: {
         nodes: {
           groupId: string;

--- a/src/traceLinkBuilder.spec.ts
+++ b/src/traceLinkBuilder.spec.ts
@@ -12,6 +12,7 @@ describe('TraceLinkBuilder', () => {
   type Example = fixtures.traceLink.Example;
   const {
     workflowId,
+    configId,
     traceId,
     data,
     hashedData,
@@ -28,7 +29,7 @@ describe('TraceLinkBuilder', () => {
 
   beforeEach(() => {
     mockUuid.mockReturnValue(traceId as any);
-    builder = new TraceLinkBuilder({ workflowId })
+    builder = new TraceLinkBuilder({ workflowId, configId })
       .forAttestation(actionKey, data)
       .withOwner(ownerId)
       .withGroup(groupId)
@@ -36,6 +37,7 @@ describe('TraceLinkBuilder', () => {
     parentLink = builder.build();
     builderWithParent = new TraceLinkBuilder({
       workflowId,
+      configId,
       parentLink
     });
   });

--- a/src/traceLinkBuilder.ts
+++ b/src/traceLinkBuilder.ts
@@ -35,7 +35,7 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
    */
   constructor(cfg: TraceLinkBuilderConfig) {
     // extract info from config
-    const { workflowId, parentLink } = cfg;
+    const { workflowId, parentLink, configId } = cfg;
 
     // trace id is either retrieved from parent link when it is provided
     // or set to a new uuid.
@@ -54,8 +54,8 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
     // may be overriden if parent link was provided
     super.withPriority(1);
 
-    // set the created at timestamp
-    this.metadata = { createdAt: new Date() };
+    // set the created at timestamp and config ID
+    this.metadata = { configId, createdAt: new Date() };
 
     // if parent link was provided set the parent hash and priority
     if (this.parentLink) {
@@ -245,6 +245,16 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
    */
   public withCreatedBy(userId: string) {
     this.metadata.createdById = userId;
+    return this;
+  }
+
+  /**
+   * To set the configId.
+   *
+   * @param configId the workflow config ID
+   */
+  public withConfigId(configId: string) {
+    this.metadata.configId = configId;
     return this;
   }
 

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -21,6 +21,11 @@ export interface SdkConfig {
   workflowId: string;
 
   /**
+   * The workflow config id
+   */
+  configId: string;
+
+  /**
    * The user id
    */
   userId: string;

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -31,6 +31,7 @@ export type TraceStageType =
  */
 export interface TraceLinkMetaData {
   ownerId: string;
+  configId: string;
   groupId: string;
   formId?: string;
   lastFormId?: string;
@@ -223,5 +224,6 @@ export interface TracesState<TState = any> extends PaginationResult {
  */
 export interface TraceLinkBuilderConfig {
   workflowId: string;
+  configId: string;
   parentLink?: ITraceLink;
 }


### PR DESCRIPTION
1. get the active wf config ID in the sdk config
2. add it to the link metadata
3. if the API returns an error because of the config ID being deprecated, update the config ID and retry.
4. In case something unexpected happens and the backend say that wf config is deprecated again, do not retry. This will allow us to avoid infinite loops in case of bad backend implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/31)
<!-- Reviewable:end -->
