### PR TITLE
Fix: Blob file encryption

### DIFF
--- a/src/fileWrapper.ts
+++ b/src/fileWrapper.ts
@@ -179,12 +179,12 @@ class NodeJsFilePathWrapper extends FileWrapper {
  * The NodeJs implementation of a FileWrapper using
  * the blob and info to represent it.
  */
-class NodeJsFileBlobWrapper extends FileWrapper {
+export class NodeJsFileBlobWrapper extends FileWrapper {
   private blob: Buffer;
   private fileInfo: FileInfo;
 
-  constructor(blob: Buffer, fileInfo: FileInfo) {
-    super(!fileInfo.key, fileInfo.key);
+  constructor(blob: Buffer, fileInfo: FileInfo, disableEncryption?: boolean) {
+    super(disableEncryption, fileInfo.key);
     this.blob = blob;
     this.fileInfo = fileInfo;
   }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,7 +38,7 @@ import {
   assignObjects,
   extractFileRecords
 } from './helpers';
-import { FileWrapper } from './fileWrapper';
+import { FileWrapper, NodeJsFileBlobWrapper } from './fileWrapper';
 import { Mutex } from 'async-mutex';
 import { FileRecord } from './fileRecord';
 
@@ -467,7 +467,7 @@ export class Sdk<TState = any> {
     const promises = Array.from(idToFileRecordMap.entries()).map(
       async ([id, record]) => {
         const file = await this.client.downloadFile(record);
-        return [id, FileWrapper.fromNodeJsFileBlob(file, record)] as [
+        return [id, new NodeJsFileBlobWrapper(file, record, !record.key)] as [
           string,
           FileWrapper
         ];


### PR DESCRIPTION
when initiating FileBlobWrapper, we explicitly pass the file info. The same class is used everywhere, which is confusing because it also contains the user file encryption key.
When the user inits a FileBlobWrapper,, he should be able to pass a null key to delegate the creation of a random key to the SDK (same as in the FilePathWrapper). Right now, when he passes the null key, the decryption is disabled.

Note: I has to create an other (internal) constructor for FileBlobWrapper where I can explicitly say if encryption is disabled or not so that we can still download non unencrypted files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/32)
<!-- Reviewable:end -->
