### PR TITLE
Breaking: Remove link and group owner (BTA-391)

### DIFF
--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -38,7 +38,6 @@ export namespace fixtures {
       hash: 'TnMst2eIwhyU7yg2izAItAyOOOrZgZDDmbRQ4G9rSqA='
     };
     export const type: TraceLinkType = 'OWNED';
-    export const ownerId = '563';
     export const configId = '666';
     export const groupId = '877';
     export const actionKey = 'action zou';
@@ -48,7 +47,6 @@ export namespace fixtures {
     export const createdAt = new Date('2019-06-26T10:13:43.873Z');
     export const createdById = '195587';
     export const metadata: TraceLinkMetaData = {
-      ownerId,
       configId,
       groupId,
       formId: actionKey,
@@ -112,7 +110,12 @@ export namespace fixtures {
       workflow: {
         config: { id: '666' },
         groups: {
-          nodes: [{ accountId: '123', groupId: '887' }]
+          nodes: [
+            {
+              groupId: '887',
+              members: { nodes: [{ accountId: '123' }] }
+            }
+          ]
         }
       }
     };

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -155,7 +155,11 @@ export namespace ConfigQuery {
         groups {
           nodes {
             groupId: rowId
-            accountId: ownerId
+            members {
+              nodes {
+                accountId
+              }
+            }
           }
         }
       }
@@ -189,7 +193,7 @@ export namespace ConfigQuery {
       groups: {
         nodes: {
           groupId: string;
-          accountId: string;
+          members: { nodes: { accountId: string }[] };
         }[];
       };
     };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -138,9 +138,10 @@ export class Sdk<TState = any> {
       // get all the account ids I am a member of
       const myAccounts = memberOf.nodes.map(a => a.accountId);
 
-      // get all the groups that are owned by one of my accounts
+      // get all the groups I belong to
+      // i.e. where I belong to one of the account members
       const myGroups = groups.nodes.filter(g =>
-        myAccounts.includes(g.accountId)
+        g.members.nodes.some(m => myAccounts.includes(m.accountId))
       );
 
       // there must be at most one group!
@@ -153,7 +154,7 @@ export class Sdk<TState = any> {
       }
 
       // extract info from my only group
-      const [{ groupId, accountId: ownerId }] = myGroups;
+      const [{ groupId }] = myGroups;
 
       // retrieve the signing private key
       let signingPrivateKey: sig.SigningPrivateKey;
@@ -179,7 +180,6 @@ export class Sdk<TState = any> {
         userId,
         accountId,
         groupId,
-        ownerId,
         signingPrivateKey
       };
 
@@ -501,13 +501,7 @@ export class Sdk<TState = any> {
     }
 
     // extract info from config
-    const {
-      workflowId,
-      userId,
-      ownerId,
-      groupId,
-      configId
-    } = await this.getConfig();
+    const { workflowId, userId, groupId, configId } = await this.getConfig();
 
     // upload files and transform data
     const dataAfterFileUpload = await this.uploadFilesInLinkData(data);
@@ -520,8 +514,6 @@ export class Sdk<TState = any> {
     })
       // this is an attestation
       .forAttestation(action, dataAfterFileUpload)
-      // add owner info
-      .withOwner(ownerId)
       // add group info
       .withGroup(groupId)
       // add creator info
@@ -575,13 +567,7 @@ export class Sdk<TState = any> {
     }
 
     // extract info from config
-    const {
-      workflowId,
-      userId,
-      ownerId,
-      groupId,
-      configId
-    } = await this.getConfig();
+    const { workflowId, userId, groupId, configId } = await this.getConfig();
 
     // upload files and transform data
     const dataAfterFileUpload = await this.uploadFilesInLinkData(data);
@@ -596,8 +582,6 @@ export class Sdk<TState = any> {
     })
       // this is an attestation
       .forAttestation(action, dataAfterFileUpload)
-      // add owner info
-      .withOwner(ownerId)
       // add group info
       .withGroup(groupId)
       // add creator info
@@ -689,13 +673,7 @@ export class Sdk<TState = any> {
     const { data } = input;
 
     // extract info from config
-    const {
-      workflowId,
-      userId,
-      ownerId,
-      groupId,
-      configId
-    } = await this.getConfig();
+    const { workflowId, userId, groupId, configId } = await this.getConfig();
 
     // use a TraceLinkBuilder to create the next link
     const linkBuilder = new TraceLinkBuilder<TLinkData>({
@@ -708,8 +686,6 @@ export class Sdk<TState = any> {
     })
       // this is to accept the transfer
       .forAcceptTransfer(data)
-      // add owner info
-      .withOwner(ownerId)
       // add group info
       .withGroup(groupId)
       // add creator info

--- a/src/traceLink.spec.ts
+++ b/src/traceLink.spec.ts
@@ -17,7 +17,6 @@ describe('TraceLink', () => {
     data,
     hashedData,
     type,
-    ownerId,
     groupId,
     actionKey,
     lastFormId,
@@ -45,7 +44,6 @@ describe('TraceLink', () => {
     expect(tLink.metadata()).toEqual(metadata);
     expect(tLink.createdBy()).toEqual(createdById);
     expect(tLink.createdAt()).toEqual(createdAt);
-    expect(tLink.owner()).toEqual(ownerId);
     expect(tLink.group()).toEqual(groupId);
     expect(tLink.form()).toEqual(actionKey);
     expect(tLink.lastForm()).toEqual(lastFormId);
@@ -60,7 +58,6 @@ describe('TraceLink', () => {
     expect(newtLink.formData()).toEqual(data);
     expect(newtLink.createdBy()).toEqual(createdById);
     expect(newtLink.createdAt()).toEqual(createdAt);
-    expect(newtLink.owner()).toEqual(ownerId);
     expect(newtLink.group()).toEqual(groupId);
     expect(newtLink.form()).toEqual(actionKey);
   });

--- a/src/traceLink.ts
+++ b/src/traceLink.ts
@@ -98,15 +98,6 @@ export class TraceLink<TLinkData = any> extends Link
   }
 
   /**
-   * The id of the owner of the trace.
-   *
-   * @returns the owner id
-   */
-  owner() {
-    return this.metadata().ownerId;
-  }
-
-  /**
    * The id of the group under which the trace is.
    *
    * @returns the group id

--- a/src/traceLinkBuilder.spec.ts
+++ b/src/traceLinkBuilder.spec.ts
@@ -16,7 +16,6 @@ describe('TraceLinkBuilder', () => {
     traceId,
     data,
     hashedData,
-    ownerId,
     groupId,
     actionKey,
     inputs,
@@ -31,7 +30,6 @@ describe('TraceLinkBuilder', () => {
     mockUuid.mockReturnValue(traceId as any);
     builder = new TraceLinkBuilder({ workflowId, configId })
       .forAttestation(actionKey, data)
-      .withOwner(ownerId)
       .withGroup(groupId)
       .withCreatedBy(createdById);
     parentLink = builder.build();
@@ -70,7 +68,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(ownerId);
     expect(link.group()).toEqual(groupId);
     expect(link.inputs()).toEqual(undefined);
     expect(link.lastForm()).toEqual(undefined);
@@ -83,7 +80,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(parentLink.owner());
     expect(link.group()).toEqual(parentLink.group());
     expect(link.inputs()).toEqual(inputs);
     expect(link.lastForm()).toEqual(parentLink.form());
@@ -96,7 +92,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(parentLink.owner());
     expect(link.group()).toEqual(parentLink.group());
     expect(link.inputs()).toEqual(inputs);
     expect(link.lastForm()).toEqual(parentLink.form());
@@ -109,7 +104,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(parentLink.owner());
     expect(link.group()).toEqual(parentLink.group());
     expect(link.inputs()).toEqual(undefined);
     expect(link.lastForm()).toEqual(undefined);
@@ -122,7 +116,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(parentLink.owner());
     expect(link.group()).toEqual(parentLink.group());
     expect(link.inputs()).toEqual(undefined);
     expect(link.lastForm()).toEqual(undefined);
@@ -135,7 +128,6 @@ describe('TraceLinkBuilder', () => {
     expect(link.data()).toEqual(hashedData);
     expect(link.action()).toEqual(expectedAction);
     expect(link.type()).toEqual(expectedType);
-    expect(link.owner()).toEqual(undefined);
     expect(link.group()).toEqual(undefined);
     expect(link.inputs()).toEqual(undefined);
     expect(link.lastForm()).toEqual(undefined);

--- a/src/traceLinkBuilder.ts
+++ b/src/traceLinkBuilder.ts
@@ -132,8 +132,7 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
     data?: TLinkData
   ) {
     const parent = this.getParentLink();
-    this.withOwner(parent.owner())
-      .withGroup(parent.group())
+    this.withGroup(parent.group())
       .withHashedData(data)
       .withAction(action)
       .withProcessState(type);
@@ -173,8 +172,7 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
     const parent = this.getParentLink();
     const action: TraceActionType = '_CANCEL_TRANSFER_';
     const type: TraceLinkType = 'OWNED';
-    this.withOwner(parent.owner())
-      .withGroup(parent.group())
+    this.withGroup(parent.group())
       .withHashedData(data)
       .withAction(action)
       .withProcessState(type);
@@ -192,8 +190,7 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
     const parent = this.getParentLink();
     const action: TraceActionType = '_REJECT_TRANSFER_';
     const type: TraceLinkType = 'OWNED';
-    this.withOwner(parent.owner())
-      .withGroup(parent.group())
+    this.withGroup(parent.group())
       .withHashedData(data)
       .withAction(action)
       .withProcessState(type);
@@ -215,16 +212,6 @@ export class TraceLinkBuilder<TLinkData = any> extends LinkBuilder {
     this.withHashedData(data)
       .withAction(action)
       .withProcessState(type);
-    return this;
-  }
-
-  /**
-   * To set the metadata ownerId.
-   *
-   * @param ownerId the owner id
-   */
-  public withOwner(ownerId: string) {
-    this.metadata.ownerId = ownerId;
     return this;
   }
 

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -41,11 +41,6 @@ export interface SdkConfig {
   groupId: string;
 
   /**
-   * The owner id
-   */
-  ownerId: string;
-
-  /**
    * The private key used for signing links
    */
   signingPrivateKey: sig.SigningPrivateKey;

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -30,7 +30,6 @@ export type TraceStageType =
  * The link metadata
  */
 export interface TraceLinkMetaData {
-  ownerId: string;
   configId: string;
   groupId: string;
   formId?: string;
@@ -50,7 +49,6 @@ export interface ITraceLink<TLinkData = any> extends Link {
   type(): TraceLinkType;
   createdBy(): Account;
   createdAt(): Date;
-  owner(): Account;
   group(): string;
   form(): string | undefined;
   lastForm(): string | undefined;


### PR DESCRIPTION
- remove mentions to link owner. At this point, owner_id should not be required by the API anymore
- remove usage of group.owner
- use group members instead to find the group which the SDK user is part of

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/47)
<!-- Reviewable:end -->
