### PR TITLE
Fix: Make sure the build works

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild": "yarn clean && yarn generate",
     "build": "tsc",
     "build:watch": "tsc -w",
-    "test": "jest --watch --runInBand",
+    "test:unit": "jest --testPathIgnorePatterns='<rootDir>/src/tests/' --watch --runInBand",
     "test:ci": "jest --coverage",
     "lint": "tslint --project \"./tsconfig.json\"",
     "release": "semantic-release",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -6,6 +6,7 @@ import { Client } from './client';
 import { fixtures } from './fixtures';
 import { FetchOptions } from './types';
 import graphqlRequest from './graphqlRequest';
+import { version as sdkVersion } from '../package.json'
 
 const fetchError = new Error('fetch error');
 const salt = bcrypt.genSaltSync();
@@ -62,7 +63,7 @@ describe('Client', () => {
           headers: {
             Authorization: '',
             'content-type': 'application/json',
-            'user-agent': expect.any(String)
+            'user-agent': expect.stringContaining(sdkVersion)
           }
         }
       );
@@ -73,7 +74,7 @@ describe('Client', () => {
           headers: {
             Authorization: '',
             'content-type': 'application/json',
-            'user-agent': expect.any(String)
+            'user-agent': expect.stringContaining(sdkVersion)
           },
           body: JSON.stringify({ email, passwordHash }),
           method: 'POST'
@@ -98,7 +99,7 @@ describe('Client', () => {
           headers: {
             Authorization: expect.stringMatching(/Bearer .*/),
             'content-type': 'application/json',
-            'user-agent': expect.any(String)
+            'user-agent': expect.stringContaining(sdkVersion)
           }
         }
       );
@@ -522,7 +523,7 @@ describe('Client', () => {
             'content-type': expect.stringContaining(
               'multipart/form-data; boundary='
             ),
-            'user-agent': expect.any(String)
+            'user-agent': expect.stringContaining(sdkVersion)
           },
           body: expect.any(Object)
         }
@@ -572,7 +573,7 @@ describe('Client', () => {
           headers: {
             Authorization: 'Bearer valid',
             'content-type': 'application/json',
-            'user-agent': expect.any(String)
+            'user-agent': expect.stringContaining(sdkVersion)
           }
         }
       );

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,6 @@ import qs, { ParsedUrlQueryInput } from 'querystring';
 import bcrypt from 'bcryptjs';
 import { Mutex } from 'async-mutex';
 import { Variables, ClientError } from 'graphql-request/dist/src/types';
-import { version as sdkVersion } from '../package.json';
 import graphqlRequest from './graphqlRequest';
 import {
   Endpoints,
@@ -28,6 +27,9 @@ import {
 import { makeEndpoints, makeAuthPayload } from './helpers';
 import { FileWrapper } from './fileWrapper';
 import HttpError from './httpError';
+
+// If we import the package.json it will change the output of the build
+const { version: sdkVersion } = require('../package.json');
 
 /**
  * The default fetch options:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,5 +71,5 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/fixtures", "src/tests", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Our sdk package from 2.0.0 onward, does not include an actual build... I think this is because the folder structure of the build was nested like this.

```
- lib
  - src
  - package.json
```

When we import package.json it gets included in the build and causes this extra nesting. If you require it seems to avoid the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-js/54)
<!-- Reviewable:end -->
